### PR TITLE
Add missing dependency to libxss (see issue #1)

### DIFF
--- a/R14.0.3/tde-tdebase/PKGBUILD
+++ b/R14.0.3/tde-tdebase/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname='tde-tdebase'
 pkgver=14.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Trinity Desktop Enviroment base components - TDE upstream GIT"
 arch=('i686' 'x86_64')
 url='http://scm.trinitydesktop.org/scm/git/tdebase'
@@ -13,6 +13,7 @@ groups=('tde-core' 'tde-base' 'tde-extra' 'tde-multimedia' 'tde-complete')
 # depends=('hal'
 depends=('libraw1394'
          'libxtst'
+         'libxss'
          'lm_sensors'
          'tde-tdelibs'
          'tde-dbus-tqt'


### PR DESCRIPTION
The Xss library is needed to build tdebase. If not installed, cmake fails to generate makefiles.

I also took the liberty to increment the pkgrel counter, maybe it wasn't needed. 