### PR TITLE
Add missing dependency to libxss (see issue #1)

### DIFF
--- a/R14.0.3/tde-tdebase/PKGBUILD
+++ b/R14.0.3/tde-tdebase/PKGBUILD
@@ -13,6 +13,7 @@ groups=('tde-core' 'tde-base' 'tde-extra' 'tde-multimedia' 'tde-complete')
 # depends=('hal'
 depends=('libraw1394'
          'libxtst'
+         'libxss'
          'lm_sensors'
          'tde-tdelibs'
          'tde-dbus-tqt'


### PR DESCRIPTION
The package tde-tdebase needs dependency to libXss (package libxss on the official archlinux repository).